### PR TITLE
feat(service): introduce service domain with lifecycle and moderation

### DIFF
--- a/prisma/migrations/20260425091832_add_service_domain/migration.sql
+++ b/prisma/migrations/20260425091832_add_service_domain/migration.sql
@@ -1,0 +1,62 @@
+-- CreateEnum
+CREATE TYPE "ServiceStatus" AS ENUM ('DRAFT', 'PENDING', 'ACTIVE', 'REJECTED', 'PAUSED', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "PriceType" AS ENUM ('FIXED', 'STARTING_FROM', 'FREE');
+
+-- AlterEnum
+ALTER TYPE "MediaKind" ADD VALUE 'service_image';
+
+-- CreateTable
+CREATE TABLE "Service" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "owner_id" TEXT NOT NULL,
+    "branch_id" TEXT,
+    "category" TEXT,
+    "price" DECIMAL(10,2),
+    "price_type" "PriceType" NOT NULL DEFAULT 'FIXED',
+    "duration" INTEGER,
+    "address" TEXT,
+    "status" "ServiceStatus" NOT NULL DEFAULT 'DRAFT',
+    "rejection_reason" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Service_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ServiceMedia" (
+    "id" TEXT NOT NULL,
+    "service_id" TEXT NOT NULL,
+    "media_id" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "ServiceMedia_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Service_owner_id_idx" ON "Service"("owner_id");
+
+-- CreateIndex
+CREATE INDEX "Service_branch_id_idx" ON "Service"("branch_id");
+
+-- CreateIndex
+CREATE INDEX "Service_status_idx" ON "Service"("status");
+
+-- CreateIndex
+CREATE INDEX "ServiceMedia_service_id_idx" ON "ServiceMedia"("service_id");
+
+-- AddForeignKey
+ALTER TABLE "Service" ADD CONSTRAINT "Service_owner_id_fkey" FOREIGN KEY ("owner_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Service" ADD CONSTRAINT "Service_branch_id_fkey" FOREIGN KEY ("branch_id") REFERENCES "Branch"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ServiceMedia" ADD CONSTRAINT "ServiceMedia_service_id_fkey" FOREIGN KEY ("service_id") REFERENCES "Service"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ServiceMedia" ADD CONSTRAINT "ServiceMedia_media_id_fkey" FOREIGN KEY ("media_id") REFERENCES "Media"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,22 @@ enum MediaKind {
   document
   branch_cover
   other
+  service_image
+}
+
+enum ServiceStatus {
+  DRAFT
+  PENDING
+  ACTIVE
+  REJECTED
+  PAUSED
+  ARCHIVED
+}
+
+enum PriceType {
+  FIXED
+  STARTING_FROM
+  FREE
 }
 
 model User {
@@ -57,6 +73,7 @@ model User {
   refresh_tokens       RefreshToken[]
   media                Media[]
   brands               Brand[]
+  services             Service[]
   brand_transfers      BrandTransfer[] @relation("BrandTransferRequester")
   received_transfers   BrandTransfer[] @relation("BrandTransferRecipient")
   brand_ratings        BrandRating[]
@@ -95,6 +112,7 @@ model Media {
   brand_logo    Brand[]        @relation("BrandLogo")
   brand_gallery BrandGallery[] @relation("BrandGallery")
   branch_covers Branch[]       @relation("BranchCover")
+  service_images ServiceMedia[]
 
   @@index([owner_id])
 }
@@ -175,6 +193,7 @@ model Branch {
   breaks      BranchBreak[]
   team        Team?         @relation("BranchTeam")
   cover_media Media?        @relation("BranchCover", fields: [cover_media_id], references: [id], onDelete: SetNull)
+  services    Service[]
 
   @@index([brand_id])
 }
@@ -326,4 +345,43 @@ model TeamMember {
   @@unique([team_id, user_id])
   @@index([team_id])
   @@index([user_id])
+}
+
+// ─── Service models ───────────────────────────────────────────────────────────
+
+model Service {
+  id               String        @id @default(cuid())
+  title            String
+  description      String?
+  owner_id         String
+  branch_id        String?
+  category         String?
+  price            Decimal?      @db.Decimal(10, 2)
+  price_type       PriceType     @default(FIXED)
+  duration         Int?
+  address          String?
+  status           ServiceStatus @default(DRAFT)
+  rejection_reason String?
+  created_at       DateTime      @default(now())
+  updated_at       DateTime      @updatedAt
+
+  owner   User           @relation(fields: [owner_id], references: [id], onDelete: Cascade)
+  branch  Branch?        @relation(fields: [branch_id], references: [id], onDelete: SetNull)
+  images  ServiceMedia[]
+
+  @@index([owner_id])
+  @@index([branch_id])
+  @@index([status])
+}
+
+model ServiceMedia {
+  id         String @id @default(cuid())
+  service_id String
+  media_id   String
+  order      Int    @default(0)
+
+  service Service @relation(fields: [service_id], references: [id], onDelete: Cascade)
+  media   Media   @relation(fields: [media_id], references: [id], onDelete: Cascade)
+
+  @@index([service_id])
 }

--- a/src/controllers/service.controller.ts
+++ b/src/controllers/service.controller.ts
@@ -1,0 +1,711 @@
+import { Request, Response, NextFunction } from 'express';
+import prisma from '../lib/prisma';
+import { sendSuccess } from '../utils/response';
+import { AppError } from '../middlewares/error.middleware';
+import { buildFileUrl } from '../services/storage.service';
+import { validateAndProcessImage, writeFileToDisk } from '../services/media.service';
+import { buildStoragePath, ensureUserStorageDir } from '../services/storage.service';
+import type { CreateServiceInput, UpdateServiceInput, RejectServiceInput } from '../schemas/service.schema';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function requireUso(req: Request, next: NextFunction): boolean {
+  if (req.user.type !== 'uso') {
+    const err: AppError = new Error();
+    err.statusCode = 403;
+    err.messageKey = 'errors.forbidden';
+    next(err);
+    return false;
+  }
+  return true;
+}
+
+function requireOwner(ownerId: string, userId: string, next: NextFunction): boolean {
+  if (ownerId !== userId) {
+    const err: AppError = new Error();
+    err.statusCode = 403;
+    err.messageKey = 'service.not_owner';
+    next(err);
+    return false;
+  }
+  return true;
+}
+
+async function validateMediaOwnership(
+  mediaIds: string[],
+  userId: string,
+  next: NextFunction,
+): Promise<boolean> {
+  if (mediaIds.length === 0) return true;
+  const medias = await prisma.media.findMany({
+    where: { id: { in: mediaIds } },
+    select: { id: true, owner_id: true },
+  });
+  const allOwned = medias.length === mediaIds.length && medias.every((m) => m.owner_id === userId);
+  if (!allOwned) {
+    const err: AppError = new Error();
+    err.statusCode = 403;
+    err.messageKey = 'media.not_owned';
+    next(err);
+    return false;
+  }
+  return true;
+}
+
+// ─── Select / map ─────────────────────────────────────────────────────────────
+
+const serviceSelect = {
+  id: true,
+  title: true,
+  description: true,
+  owner_id: true,
+  branch_id: true,
+  category: true,
+  price: true,
+  price_type: true,
+  duration: true,
+  address: true,
+  status: true,
+  rejection_reason: true,
+  created_at: true,
+  updated_at: true,
+  images: {
+    select: {
+      id: true,
+      media_id: true,
+      order: true,
+      media: { select: { id: true, storage_path: true } },
+    },
+    orderBy: { order: 'asc' as const },
+  },
+} as const;
+
+function mapService(raw: any) {
+  return {
+    id: raw.id,
+    title: raw.title,
+    description: raw.description ?? undefined,
+    owner_id: raw.owner_id,
+    branch_id: raw.branch_id ?? null,
+    category: raw.category ?? undefined,
+    price: raw.price ? Number(raw.price) : null,
+    price_type: raw.price_type,
+    duration: raw.duration ?? null,
+    address: raw.address ?? undefined,
+    status: raw.status,
+    rejection_reason: raw.rejection_reason ?? undefined,
+    images: raw.images.map((img: any) => ({
+      id: img.id,
+      media_id: img.media_id,
+      order: img.order,
+      url: buildFileUrl(img.media.storage_path),
+    })),
+    created_at: raw.created_at.toISOString(),
+    updated_at: raw.updated_at.toISOString(),
+  };
+}
+
+const SIGNIFICANT_FIELDS = ['title', 'description', 'price', 'price_type', 'duration', 'address', 'branch_id'] as const;
+
+// ─── Media upload ─────────────────────────────────────────────────────────────
+
+export const uploadServiceMedia = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!requireUso(req, next)) return;
+
+    const userId = req.user.sub;
+
+    if (!req.file) {
+      const err: AppError = new Error();
+      err.statusCode = 400;
+      err.messageKey = 'media.no_file_provided';
+      return next(err);
+    }
+
+    const validated = await validateAndProcessImage(req.file);
+
+    await ensureUserStorageDir(userId);
+    const storagePath = buildStoragePath(userId, 'webp');
+    await writeFileToDisk(storagePath, validated.buffer);
+
+    const media = await prisma.media.create({
+      data: {
+        name: req.file.originalname,
+        format: validated.format,
+        mime_type: validated.mimeType,
+        size: validated.size,
+        kind: 'service_image',
+        storage_path: storagePath,
+        checksum: validated.checksum,
+        width: validated.width,
+        height: validated.height,
+        is_public: true,
+        owner_id: userId,
+      },
+    });
+
+    sendSuccess({
+      res,
+      status: 201,
+      message: 'media.service_upload_success',
+      data: { media_id: media.id, url: buildFileUrl(storagePath) },
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Create ───────────────────────────────────────────────────────────────────
+
+export const createService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!requireUso(req, next)) return;
+
+    const userId = req.user.sub;
+    const body = req.body as CreateServiceInput;
+
+    // Validate branch membership if branch_id provided
+    if (body.branch_id) {
+      const membership = await prisma.teamMember.findFirst({
+        where: { team: { branch_id: body.branch_id }, user_id: userId, status: 'ACCEPTED' },
+      });
+      if (!membership) {
+        const err: AppError = new Error();
+        err.statusCode = 403;
+        err.messageKey = 'service.not_branch_member';
+        return next(err);
+      }
+    }
+
+    // Validate image media ownership
+    const imageIds = body.image_media_ids ?? [];
+    if (!(await validateMediaOwnership(imageIds, userId, next))) return;
+
+    const service = await prisma.service.create({
+      data: {
+        title: body.title,
+        description: body.description,
+        owner_id: userId,
+        branch_id: body.branch_id ?? null,
+        category: body.category,
+        price: body.price !== undefined ? body.price : null,
+        price_type: body.price_type ?? 'FIXED',
+        duration: body.duration ?? null,
+        address: body.address,
+        status: 'DRAFT',
+        images:
+          imageIds.length > 0
+            ? {
+                create: imageIds.map((mediaId, index) => ({
+                  media_id: mediaId,
+                  order: index,
+                })),
+              }
+            : undefined,
+      },
+      select: serviceSelect,
+    });
+
+    sendSuccess({ res, status: 201, message: 'service.created', data: { service: mapService(service) } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── My services ──────────────────────────────────────────────────────────────
+
+export const getMyServices = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!requireUso(req, next)) return;
+
+    const userId = req.user.sub;
+
+    const services = await prisma.service.findMany({
+      where: { owner_id: userId },
+      select: serviceSelect,
+      orderBy: { created_at: 'desc' },
+    });
+
+    sendSuccess({ res, status: 200, message: 'service.list', data: { services: services.map(mapService) } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Public listing ───────────────────────────────────────────────────────────
+
+export const listPublicServices = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const category = typeof req.query['category'] === 'string' ? req.query['category'] : undefined;
+    const branch_id = typeof req.query['branch_id'] === 'string' ? req.query['branch_id'] : undefined;
+    const q = typeof req.query['q'] === 'string' ? req.query['q'] : undefined;
+
+    const services = await prisma.service.findMany({
+      where: {
+        status: 'ACTIVE',
+        ...(category && { category }),
+        ...(branch_id && { branch_id }),
+        ...(q && {
+          OR: [
+            { title: { contains: q, mode: 'insensitive' } },
+            { description: { contains: q, mode: 'insensitive' } },
+          ],
+        }),
+      },
+      select: serviceSelect,
+      orderBy: { created_at: 'desc' },
+    });
+
+    sendSuccess({ res, status: 200, message: 'service.list', data: { services: services.map(mapService) } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Get by ID ────────────────────────────────────────────────────────────────
+
+export const getServiceById = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const id = req.params['id'] as string;
+
+    const service = await prisma.service.findUnique({ where: { id }, select: serviceSelect });
+
+    if (!service) {
+      const err: AppError = new Error();
+      err.statusCode = 404;
+      err.messageKey = 'service.not_found';
+      return next(err);
+    }
+
+    // Non-ACTIVE services are only visible to their owner
+    if (service.status !== 'ACTIVE') {
+      const userId = req.user?.sub;
+      if (!userId || service.owner_id !== userId) {
+        const err: AppError = new Error();
+        err.statusCode = 404;
+        err.messageKey = 'service.not_found';
+        return next(err);
+      }
+    }
+
+    sendSuccess({ res, status: 200, message: 'service.found', data: { service: mapService(service) } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Update ───────────────────────────────────────────────────────────────────
+
+export const updateService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!requireUso(req, next)) return;
+
+    const id = req.params['id'] as string;
+    const userId = req.user.sub;
+    const body = req.body as UpdateServiceInput;
+
+    const existing = await prisma.service.findUnique({
+      where: { id },
+      select: { owner_id: true, status: true },
+    });
+
+    if (!existing) {
+      const err: AppError = new Error();
+      err.statusCode = 404;
+      err.messageKey = 'service.not_found';
+      return next(err);
+    }
+
+    if (!requireOwner(existing.owner_id, userId, next)) return;
+
+    const { status } = existing;
+
+    // PAUSED, ARCHIVED, PENDING cannot be edited
+    if (status === 'PAUSED' || status === 'ARCHIVED' || status === 'PENDING') {
+      const err: AppError = new Error();
+      err.statusCode = 400;
+      err.messageKey = 'service.cannot_update_in_current_status';
+      return next(err);
+    }
+
+    // Determine if re-moderation is needed (ACTIVE service with significant changes)
+    const hasSignificantFieldChange = SIGNIFICANT_FIELDS.some(
+      (field) => body[field] !== undefined,
+    );
+    const hasImageChange = body.image_media_ids !== undefined;
+    const needsRemoderation = status === 'ACTIVE' && (hasSignificantFieldChange || hasImageChange);
+
+    // Validate image ownership if images are being replaced
+    const imageIds = body.image_media_ids;
+    if (imageIds !== undefined) {
+      if (!(await validateMediaOwnership(imageIds, userId, next))) return;
+      // Replace all existing images
+      await prisma.serviceMedia.deleteMany({ where: { service_id: id } });
+    }
+
+    const service = await prisma.service.update({
+      where: { id },
+      data: {
+        ...(body.title !== undefined && { title: body.title }),
+        ...(body.description !== undefined && { description: body.description }),
+        ...(body.branch_id !== undefined && { branch_id: body.branch_id }),
+        ...(body.category !== undefined && { category: body.category }),
+        ...(body.price !== undefined && { price: body.price }),
+        ...(body.price_type !== undefined && { price_type: body.price_type }),
+        ...(body.duration !== undefined && { duration: body.duration }),
+        ...(body.address !== undefined && { address: body.address }),
+        ...(needsRemoderation && { status: 'PENDING', rejection_reason: null }),
+        ...(imageIds !== undefined &&
+          imageIds.length > 0 && {
+            images: {
+              create: imageIds.map((mediaId, index) => ({ media_id: mediaId, order: index })),
+            },
+          }),
+      },
+      select: serviceSelect,
+    });
+
+    sendSuccess({ res, status: 200, message: 'service.updated', data: { service: mapService(service) } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Delete ───────────────────────────────────────────────────────────────────
+
+export const deleteService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!requireUso(req, next)) return;
+
+    const id = req.params['id'] as string;
+    const userId = req.user.sub;
+
+    const existing = await prisma.service.findUnique({
+      where: { id },
+      select: { owner_id: true, status: true },
+    });
+
+    if (!existing) {
+      const err: AppError = new Error();
+      err.statusCode = 404;
+      err.messageKey = 'service.not_found';
+      return next(err);
+    }
+
+    if (!requireOwner(existing.owner_id, userId, next)) return;
+
+    if (existing.status !== 'DRAFT' && existing.status !== 'REJECTED') {
+      const err: AppError = new Error();
+      err.statusCode = 400;
+      err.messageKey = 'service.cannot_delete_in_current_status';
+      return next(err);
+    }
+
+    await prisma.service.delete({ where: { id } });
+
+    sendSuccess({ res, status: 200, message: 'service.deleted' });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Lifecycle transitions ────────────────────────────────────────────────────
+
+export const submitService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!requireUso(req, next)) return;
+
+    const id = req.params['id'] as string;
+    const userId = req.user.sub;
+
+    const existing = await prisma.service.findUnique({
+      where: { id },
+      select: { owner_id: true, status: true },
+    });
+
+    if (!existing) {
+      const err: AppError = new Error();
+      err.statusCode = 404;
+      err.messageKey = 'service.not_found';
+      return next(err);
+    }
+
+    if (!requireOwner(existing.owner_id, userId, next)) return;
+
+    if (existing.status !== 'DRAFT' && existing.status !== 'REJECTED') {
+      const err: AppError = new Error();
+      err.statusCode = 400;
+      err.messageKey = 'service.cannot_submit_in_current_status';
+      return next(err);
+    }
+
+    const service = await prisma.service.update({
+      where: { id },
+      data: { status: 'PENDING', rejection_reason: null },
+      select: serviceSelect,
+    });
+
+    sendSuccess({ res, status: 200, message: 'service.submitted', data: { service: mapService(service) } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const pauseService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!requireUso(req, next)) return;
+
+    const id = req.params['id'] as string;
+    const userId = req.user.sub;
+
+    const existing = await prisma.service.findUnique({
+      where: { id },
+      select: { owner_id: true, status: true },
+    });
+
+    if (!existing) {
+      const err: AppError = new Error();
+      err.statusCode = 404;
+      err.messageKey = 'service.not_found';
+      return next(err);
+    }
+
+    if (!requireOwner(existing.owner_id, userId, next)) return;
+
+    if (existing.status !== 'ACTIVE') {
+      const err: AppError = new Error();
+      err.statusCode = 400;
+      err.messageKey = 'service.cannot_pause_in_current_status';
+      return next(err);
+    }
+
+    const service = await prisma.service.update({
+      where: { id },
+      data: { status: 'PAUSED' },
+      select: serviceSelect,
+    });
+
+    sendSuccess({ res, status: 200, message: 'service.paused', data: { service: mapService(service) } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const resumeService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!requireUso(req, next)) return;
+
+    const id = req.params['id'] as string;
+    const userId = req.user.sub;
+
+    const existing = await prisma.service.findUnique({
+      where: { id },
+      select: { owner_id: true, status: true },
+    });
+
+    if (!existing) {
+      const err: AppError = new Error();
+      err.statusCode = 404;
+      err.messageKey = 'service.not_found';
+      return next(err);
+    }
+
+    if (!requireOwner(existing.owner_id, userId, next)) return;
+
+    if (existing.status !== 'PAUSED') {
+      const err: AppError = new Error();
+      err.statusCode = 400;
+      err.messageKey = 'service.cannot_resume_in_current_status';
+      return next(err);
+    }
+
+    const service = await prisma.service.update({
+      where: { id },
+      data: { status: 'ACTIVE' },
+      select: serviceSelect,
+    });
+
+    sendSuccess({ res, status: 200, message: 'service.resumed', data: { service: mapService(service) } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const archiveService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!requireUso(req, next)) return;
+
+    const id = req.params['id'] as string;
+    const userId = req.user.sub;
+
+    const existing = await prisma.service.findUnique({
+      where: { id },
+      select: { owner_id: true, status: true },
+    });
+
+    if (!existing) {
+      const err: AppError = new Error();
+      err.statusCode = 404;
+      err.messageKey = 'service.not_found';
+      return next(err);
+    }
+
+    if (!requireOwner(existing.owner_id, userId, next)) return;
+
+    if (existing.status !== 'ACTIVE' && existing.status !== 'PAUSED') {
+      const err: AppError = new Error();
+      err.statusCode = 400;
+      err.messageKey = 'service.cannot_archive_in_current_status';
+      return next(err);
+    }
+
+    const service = await prisma.service.update({
+      where: { id },
+      data: { status: 'ARCHIVED' },
+      select: serviceSelect,
+    });
+
+    sendSuccess({ res, status: 200, message: 'service.archived', data: { service: mapService(service) } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ─── Moderation (admin) ───────────────────────────────────────────────────────
+
+export const approveService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (req.user.type !== 'admin') {
+      const err: AppError = new Error();
+      err.statusCode = 403;
+      err.messageKey = 'errors.forbidden';
+      return next(err);
+    }
+
+    const id = req.params['id'] as string;
+
+    const existing = await prisma.service.findUnique({
+      where: { id },
+      select: { status: true },
+    });
+
+    if (!existing) {
+      const err: AppError = new Error();
+      err.statusCode = 404;
+      err.messageKey = 'service.not_found';
+      return next(err);
+    }
+
+    if (existing.status !== 'PENDING') {
+      const err: AppError = new Error();
+      err.statusCode = 400;
+      err.messageKey = 'service.cannot_approve_in_current_status';
+      return next(err);
+    }
+
+    const service = await prisma.service.update({
+      where: { id },
+      data: { status: 'ACTIVE', rejection_reason: null },
+      select: serviceSelect,
+    });
+
+    sendSuccess({ res, status: 200, message: 'service.approved', data: { service: mapService(service) } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const rejectService = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (req.user.type !== 'admin') {
+      const err: AppError = new Error();
+      err.statusCode = 403;
+      err.messageKey = 'errors.forbidden';
+      return next(err);
+    }
+
+    const id = req.params['id'] as string;
+    const body = req.body as RejectServiceInput;
+
+    const existing = await prisma.service.findUnique({
+      where: { id },
+      select: { status: true },
+    });
+
+    if (!existing) {
+      const err: AppError = new Error();
+      err.statusCode = 404;
+      err.messageKey = 'service.not_found';
+      return next(err);
+    }
+
+    if (existing.status !== 'PENDING') {
+      const err: AppError = new Error();
+      err.statusCode = 400;
+      err.messageKey = 'service.cannot_reject_in_current_status';
+      return next(err);
+    }
+
+    const service = await prisma.service.update({
+      where: { id },
+      data: { status: 'REJECTED', rejection_reason: body.rejection_reason },
+      select: serviceSelect,
+    });
+
+    sendSuccess({ res, status: 200, message: 'service.rejected', data: { service: mapService(service) } });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -6,6 +6,7 @@ import mediaRoute from './media.route';
 import brandRoute from './brand.route';
 import notificationRoute from './notification.route';
 import teamRoute from './team.route';
+import serviceRoute from './service.route';
 
 const router: Router = Router();
 
@@ -16,5 +17,6 @@ router.use('/users', mediaRoute);
 router.use('/', brandRoute);
 router.use('/notifications', notificationRoute);
 router.use('/', teamRoute);
+router.use('/', serviceRoute);
 
 export default router;

--- a/src/routes/v1/service.route.ts
+++ b/src/routes/v1/service.route.ts
@@ -1,0 +1,73 @@
+import { Router } from 'express';
+import multer from 'multer';
+import {
+  uploadServiceMedia,
+  createService,
+  getMyServices,
+  listPublicServices,
+  getServiceById,
+  updateService,
+  deleteService,
+  submitService,
+  pauseService,
+  resumeService,
+  archiveService,
+  approveService,
+  rejectService,
+} from '../../controllers/service.controller';
+import { authenticate } from '../../middlewares/auth.middleware';
+import { validate } from '../../middlewares/validate.middleware';
+import { AppError } from '../../middlewares/error.middleware';
+import {
+  createServiceSchema,
+  updateServiceSchema,
+  rejectServiceSchema,
+} from '../../schemas/service.schema';
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    const allowed = ['image/jpeg', 'image/png', 'image/webp'];
+    if (allowed.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      const err: AppError = new Error();
+      err.statusCode = 415;
+      err.messageKey = 'media.invalid_file_type';
+      cb(err as unknown as null, false);
+    }
+  },
+});
+
+const router: Router = Router();
+
+// ─── Service media upload ──────────────────────────────────────────────────────
+
+router.post('/services/media', authenticate, upload.single('file'), uploadServiceMedia);
+
+// ─── Public listing ────────────────────────────────────────────────────────────
+
+router.get('/services', listPublicServices);
+
+// ─── Authenticated routes ──────────────────────────────────────────────────────
+
+router.get('/services/mine', authenticate, getMyServices);
+router.post('/services', authenticate, validate(createServiceSchema), createService);
+router.get('/services/:id', authenticate, getServiceById);
+router.patch('/services/:id', authenticate, validate(updateServiceSchema), updateService);
+router.delete('/services/:id', authenticate, deleteService);
+
+// ─── Lifecycle transitions ────────────────────────────────────────────────────
+
+router.post('/services/:id/submit', authenticate, submitService);
+router.post('/services/:id/pause', authenticate, pauseService);
+router.post('/services/:id/resume', authenticate, resumeService);
+router.post('/services/:id/archive', authenticate, archiveService);
+
+// ─── Moderation (admin) ────────────────────────────────────────────────────────
+
+router.post('/services/:id/approve', authenticate, approveService);
+router.post('/services/:id/reject', authenticate, validate(rejectServiceSchema), rejectService);
+
+export default router;

--- a/src/schemas/service.schema.ts
+++ b/src/schemas/service.schema.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+export const createServiceSchema = z.object({
+  title: z.string().min(2, 'Title must be at least 2 characters').max(150).trim(),
+  description: z.string().max(2000).trim().optional(),
+  branch_id: z.string().cuid('Invalid branch id').nullable().optional(),
+  category: z.string().max(100).trim().optional(),
+  price: z.number().positive().optional(),
+  price_type: z.enum(['FIXED', 'STARTING_FROM', 'FREE']).default('FIXED'),
+  duration: z.number().int().positive().max(1440).optional(),
+  address: z.string().max(500).trim().optional(),
+  image_media_ids: z.array(z.string().cuid('Invalid media id')).optional().default([]),
+}).refine(
+  (data) => data.branch_id || data.address,
+  { message: 'Either branch_id or address is required for an individual service', path: ['address'] },
+);
+
+export type CreateServiceInput = z.infer<typeof createServiceSchema>;
+
+export const updateServiceSchema = z.object({
+  title: z.string().min(2).max(150).trim().optional(),
+  description: z.string().max(2000).trim().nullable().optional(),
+  branch_id: z.string().cuid('Invalid branch id').nullable().optional(),
+  category: z.string().max(100).trim().nullable().optional(),
+  price: z.number().positive().nullable().optional(),
+  price_type: z.enum(['FIXED', 'STARTING_FROM', 'FREE']).optional(),
+  duration: z.number().int().positive().max(1440).nullable().optional(),
+  address: z.string().max(500).trim().nullable().optional(),
+  image_media_ids: z.array(z.string().cuid('Invalid media id')).optional(),
+});
+
+export type UpdateServiceInput = z.infer<typeof updateServiceSchema>;
+
+export const rejectServiceSchema = z.object({
+  rejection_reason: z.string().min(10).max(1000).trim(),
+});
+
+export type RejectServiceInput = z.infer<typeof rejectServiceSchema>;


### PR DESCRIPTION
- Add Service, ServiceMedia Prisma models with ServiceStatus/PriceType enums
- Add service_image to MediaKind enum; add relations in User, Branch, Media
- Implement CRUD + lifecycle endpoints (draft, submit, approve, reject, pause, resume, archive)
- Context validation: branch membership or address required
- Significant field edits on ACTIVE services trigger re-moderation (PENDING)
- Public service listing and detail endpoints

Closes #9